### PR TITLE
chore(ci): add Makefile target to clean local CI artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,10 @@ clean:
 	rm -f ./dependencies.csv
 	rm -f ./gokiburi.spdx.sbom
 
+clean-ci: # @HELP removes Docker containers, volumes, and images for Dagger CI
+clean-ci:
+	scripts/clean-ci.sh
+
 gen-deps-csv: # @HELP generates CSV of dependencies to ./dependencies.csv
 gen-deps-csv:
 	go run ci/main.go -run gen-deps-csv

--- a/scripts/clean-ci.sh
+++ b/scripts/clean-ci.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if ! command -v "docker" >/dev/null 2>&1; then
+    echo "docker is not installed. https://docs.docker.com/desktop/"
+    exit 1
+fi
+
+daggerContainer=$(docker container list --all --filter 'name=^dagger-engine-*' --format '{{.Names}}')
+daggerImage=$(docker image list --all --filter=reference='registry.dagger.io/engine' --format '{{.ID}}')
+
+if [ "$daggerContainer" != "" ]; then
+    echo -n "stopping dagger engine container: $daggerContainer "
+    docker container stop "$daggerContainer" >/dev/null
+    echo "SUCCESS"
+
+    echo -n "removing dagger engine container: $daggerContainer "
+    docker container rm --volumes "$daggerContainer" >/dev/null
+    echo "SUCCESS"
+else
+    echo "dagger engine container not found"
+fi
+
+if [ "$daggerImage" != "" ]; then
+    echo -n "removing dagger engine image: $daggerImage "
+    docker image rm "$daggerImage" >/dev/null
+    echo "SUCCESS"
+else
+    echo "dagger engine image not found"
+fi


### PR DESCRIPTION
Adds a script and Makefile target to clean local CI artifacts such as Docker containers, volumes, and images for Dagger CI:

```console
$ make clean-ci
stopping dagger engine container: dagger-engine-21bb4df91b5042d6 SUCCESS
removing dagger engine container: dagger-engine-21bb4df91b5042d6 SUCCESS
removing dagger engine image: 31cb8fd1c856 SUCCESS
```